### PR TITLE
C:\\\\Python36 --> C:\\\\Python37

### DIFF
--- a/tutorial/interpreter.po
+++ b/tutorial/interpreter.po
@@ -54,7 +54,7 @@ msgid ""
 "the installer.  To add this directory to your path,  you can type the "
 "following command into the command prompt in a DOS box::"
 msgstr ""
-"윈도우에서, 파이썬 설치는 보통 :file:`C:\\\\Python36` 에 이루어지지만, 설치기를 실행할 때 변경할 수 있습니다."
+"윈도우에서, 파이썬 설치는 보통 :file:`C:\\\\Python37` 에 이루어지지만, 설치기를 실행할 때 변경할 수 있습니다."
 " 이 디렉터리를 경로에 넣으려면 다음과 같은 명령을 DOS 상자의 명령 프롬프트에 입력하면 됩니다::"
 
 #: ../Doc/tutorial/interpreter.rst:33


### PR DESCRIPTION
윈도우 파이썬 설치 부분에서 C:\\\\Python36 --> C:\\\\Python37 로 변경했습니다. fuzzy되어 있어서 공식 문서에 이 부분만 영문으로 나오네요.