### PR TITLE
library/unittest.mock-examples 번역

### DIFF
--- a/library/unittest.mock-examples.po
+++ b/library/unittest.mock-examples.po
@@ -45,7 +45,7 @@ msgstr "객체에 대한 메서드 호출 기록"
 msgid ""
 "You might want to replace a method on an object to check that it is "
 "called with the correct arguments by another part of the system:"
-msgstr "객체의 메서드를 대체하여 시스템의 다른 부분에서 올바른 인수로 호출되었는지 확인할 수 있습니다.:"
+msgstr "객체의 메서드를 대체하여 시스템의 다른 부분에서 올바른 인수로 호출되는지 확인 할 수 있습니다:"
 
 #: ../Doc/library/unittest.mock-examples.rst:31
 msgid ""
@@ -84,7 +84,7 @@ msgstr ""
 
 #: ../Doc/library/unittest.mock-examples.rst:62
 msgid "Mock for Method Calls on an Object"
-msgstr "객체에 대한 메서드 호출 Mock하기"
+msgstr "객체에 대한 메서드 호출 Mock 하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:64
 msgid ""
@@ -118,7 +118,7 @@ msgid ""
 ":meth:`~Mock.assert_called_with` will raise a failure exception."
 msgstr ""
 "우리는 mock에 'close' 메서드를 제공하기 위해 어떠한 노력도 하지 않아도 됩니다. close에 접근하면, 해당 메서드가 "
-"생성됩니다. 따라서 'close'가 아직 호출되지 않았다면, 테스트에서 접근하면 생성되지만, "
+"생성됩니다. 따라서 'close'가 아직 호출되지 않았다면, 테스트에 접근하면 생성되지만, "
 ":meth:`~Mock.assert_called_with` 는 실패 예외를 발생시킵니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:92
@@ -272,7 +272,7 @@ msgid ""
 " returns the next value from the iterable:"
 msgstr ""
 "``side_effect`` 역시 함수 혹은 이터러블로 설정할 수 있습니다. 이터러블로 ``side_effect`` 를 사용하는 "
-"사례는 mock이 여러 번 호출되는 곳이며, 호출마다다른 값을 반환하기 원하는 경우입니다. ``side_effect`` 를 "
+"사례는 mock이 여러 번 호출되는 곳이며, 호출마다 다른 값을 반환하기 원하는 경우입니다. ``side_effect`` 를 "
 "이터러블로 설정하면, mock을 호출 할 때마다 다음 값을 반환합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:250
@@ -282,7 +282,7 @@ msgid ""
 "function. The function will be called with the same arguments as the "
 "mock. Whatever the function returns is what the call returns:"
 msgstr ""
-"mock이 호출되는 것에 따라 반환 값이 동적으로 바뀌는 것과 같은 고급 사용 사례의 경우, ``side_effect`` 가 함수가"
+"mock이 호출되는 것에 따라 반환 값이 동적으로 바뀌는 것과 같은 고급 사용 사례의 경우, ``side_effect`` 는 함수가"
 " 될 수 있습니다. 이 함수는 mock과 같은 인자로 호출됩니다. 어떠한 함수 반환이든 간에 호출이 반환하는 것입니다.:"
 
 # TODO specification 논의
@@ -316,7 +316,7 @@ msgid ""
 msgstr ""
 ":class:`Mock` 은 *spec* 키워드 인자를 사용하여 mock 객체를 정의할 수 있게 합니다. 정의된 mock 객체에 "
 "존재하지 않는 메서드 / 속성에 접근하면, 속성 오류가 즉시 발생합니다. 만약 정의을 변경하면, 해당 클래스를 사용하는 테스트는 "
-"해당 테스트에서 클래스를 인스턴스화하지 않고도 즉시 실패합니다."
+"해당 테스트에서 클래스를 인스턴스화하지 않고 즉시 실패합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:289
 msgid ""
@@ -354,7 +354,7 @@ msgid ""
 "where they are looked up. This is normally straightforward, but for a "
 "quick guide read :ref:`where to patch <where-to-patch>`."
 msgstr ""
-":func:`patch` 를 사용하면 룩업된 네임스페이스의 객체들을 패치하는 것이 중요합니다. 이것은 일반적으로 간단하지만, 빠른 "
+":func:`patch` 를 사용하면 룩업된 네임스페이스의 객체들을 패치하는 것이 중요합니다. 일반적으로 간단하지만, 빠른 "
 "안내 위해 :ref:`where to patch <where-to-patch>` 를 참고하세요."
 
 #: ../Doc/library/unittest.mock-examples.rst:319
@@ -424,7 +424,7 @@ msgid ""
 "decorators are applied). This means from the bottom up, so in the example"
 " above the mock for ``test_module.ClassName2`` is passed in first."
 msgstr ""
-"패치 데코레이터를 중첩하여 사용할 때, mock은 데코레이터가 적용된 순서대로 (데코레이터가 적용된 일반적인 **파이썬** 순서) "
+"패치 데코레이터를 중첩하여 사용할 때, mock은 데코레이터가 적용된 순서대로 (데코레이터가 적용되는 일반적인 **파이썬** 순서) "
 "데코레이팅 된 함수에 전달됩니다. 즉, 위에서 아래로 적용되는 것을 의미합니다. 위의 예제에서 "
 "``test_module.ClassName2`` 가 먼저 mock에 전달됩니다."
 
@@ -527,7 +527,7 @@ msgid ""
 msgstr ""
 "``Something`` 인스턴스에 ``backend`` 속성을 몽키패치(Monkey Patch) 할 수 있는 인스턴스 속성으로부터"
 " 호출의 연결이 생성됩니다. 이러한 특별 케이스에서는 ``start_call``\\에 대한 최종 호출의 반환 값에만 관심이 있기 "
-"때문에 많은 구성이 필요하지 않습니다.반환하는 객체가 '파일형'이라고 가정하고, 응답 객체를 내장된 :func:`open` 을 "
+"때문에 많은 구성이 필요하지 않습니다. 반환하는 객체가 '파일형'이라고 가정하고, 응답 객체를 내장된 :func:`open` 을 "
 "``spec`` 로 사용하도록 할 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:490
@@ -608,7 +608,7 @@ msgid ""
 "``date`` in the module that *uses* it. See :ref:`where to patch <where-"
 "to-patch>`."
 msgstr ""
-":class:`datetime.date` 를 전역적으로 패치하지 않고, *사용* 하려는 모듈에서 ``date`` 를 패치합니다. "
+":class:`datetime.date` 를 전역으로 패치하지 않고, *사용* 하려는 모듈에서 ``date`` 를 패치합니다. "
 ":ref:`where to patch <where-to-patch>` 를 참고하세요."
 
 # TODO (2019. 5) 안티 패턴 해석 어색
@@ -621,7 +621,7 @@ msgid ""
 "anti-pattern."
 msgstr ""
 "``date.today()``\\가 호출 되면, 알려진 날짜가 반환되지만, ``date(...)`` 생성자는 여전히 정상 날짜를 "
-"호출합니다. 이것이 없다면 고전적인 안티 패턴 테스트인 테스트 중인 코드와 같은 알고리즘을 사용하여 예상 결과를계산해야 한다는 것을"
+"호출합니다. 이것이 없다면 고전적인 안티 패턴 테스트인 테스트 중인 코드와 같은 알고리즘을 사용하여 예상 결과를 계산해야 한다는 것을"
 " 알 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:556
@@ -975,7 +975,7 @@ msgid ""
 "After the ``MagicMock`` has been used we can use attributes like "
 ":data:`~Mock.call_args_list` to assert about how the dictionary was used:"
 msgstr ""
-"``MagicMock`` 가 사용 된 후에는 :data:`~Mock.call_args_list` 와 같은 속성을 사용하여딕셔너리가 "
+"``MagicMock`` 가 사용 된 후에는 :data:`~Mock.call_args_list` 와 같은 속성을 사용하여 딕셔너리가 "
 "어떻게 사용되었는지 어서트 할 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:939
@@ -1059,7 +1059,7 @@ msgid ""
 "(``**kwargs``) which are then passed onto the mock constructor:"
 msgstr ""
 "(모든 속성에서) ``Mock`` 은 ``_get_child_mock`` 호출을 이용하여, 속성과 반환 값에 대한 "
-"\"하위-mock\" 을 만듭니다. 이 메서드를 오버라이드하는 것이므로, 하위 클래스가 속성에 사용되지 않게 할 수 있습니다.서명은"
+"\"하위-mock\" 을 만듭니다. 이 메서드를 오버라이드하는 것이므로, 하위 클래스가 속성에 사용되지 않게 할 수 있습니다. 사인은"
 " 임의의 키워드 인자(``**kwargs``) 를 가지고, mock 생성자로 전달 된다는 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1042
@@ -1120,7 +1120,7 @@ msgid ""
 msgstr ""
 "즉 :func:`patch.dict` 를 사용하여 *일시적으로* mock 을 :data:`sys.modules` 에 배치합니다. 이"
 " 패치가 임포트 되어있는 동안, mock 을 가져옵니다. 패치가 완료되면 (데코레이팅 된 함수가 종료되면, with 문이 완전히 "
-"완료되거나 ``patcher.stop()`` 이 호출 됩니다.) 이전 무엇이 있든 안전하게 복원 될 것입니다."
+"완료되거나 ``patcher.stop()`` 이 호출 됩니다.) 이전에 무엇이 있든 안전하게 복원 될 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1074
 msgid "Here's an example that mocks out the 'fooble' module."
@@ -1194,7 +1194,7 @@ msgid ""
 " in :attr:`~Mock.mock_calls` then the assert succeeds."
 msgstr ""
 "많은 호출이 생성되었지만, 특정 순서에만 관심있다면 :meth:`~Mock.assert_has_calls` 메서드를 사용하는 방법도"
-" 있습니다. 이것은 (호출 객체로 생성된) 호출 목록을 가지고 있습니다 해당 호출 순서가 "
+" 있습니다. 이것은 ( :data:`call` 생성된) 호출 목록을 가지고 있습니다 해당 호출 순서가 "
 ":attr:`~Mock.mock_calls` 이면, 어서트가 성공합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1176
@@ -1294,3 +1294,4 @@ msgstr ""
 " 부터 동등 matcher (`hamcrest.library.integration.match_equality "
 "<https://pyhamcrest.readthedocs.io/en/release-1.8/integration/#module-"
 "hamcrest.library.integration.match_equality>`_) 의 형태로 비슷한 기능을 제공합니다."
+

--- a/library/unittest.mock-examples.po
+++ b/library/unittest.mock-examples.po
@@ -229,7 +229,7 @@ msgid ""
 " call."
 msgstr ""
 "``mock.connection.cursor().execute(\"SELECT 1\")`` 같은 예제처럼 때로는 좀 더 복잡한 "
-"상황을 목업(mockup) 하고 싶을 때가 있습니다. 만약 이 호출을 리스트로 반환하려면, 중첩 호출의 결과를 구성해야 합니다."
+"상황을 목업(mock up) 하고 싶을 때가 있습니다. 만약 이 호출을 리스트로 반환하려면, 중첩 호출의 결과를 구성해야 합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:200
 msgid ""

--- a/library/unittest.mock-examples.po
+++ b/library/unittest.mock-examples.po
@@ -125,8 +125,6 @@ msgstr ""
 msgid "Mocking Classes"
 msgstr "Mocking 클래스"
 
-# TODO (2019. 5) mock out, mocked 해석 어색
-# https://en.wiktionary.org/wiki/mock_out
 #: ../Doc/library/unittest.mock-examples.rst:94
 msgid ""
 "A common use case is to mock out classes instantiated by your code under "
@@ -177,7 +175,6 @@ msgstr ""
 "종종 메서드에 대한 단일 호출 이상을 추적하려고 합니다. :attr:`~Mock.mock_calls` 속성은 모든 mock의 자식 "
 "속성 (또는 그들의 자식 속성에) 대한 호출 기록합니다."
 
-# TODO (2019. 5) assertion 해석 어색
 #: ../Doc/library/unittest.mock-examples.rst:144
 msgid ""
 "If you make an assertion about ``mock_calls`` and any unexpected methods "
@@ -285,7 +282,6 @@ msgstr ""
 "mock이 호출되는 것에 따라 반환 값이 동적으로 바뀌는 것과 같은 고급 사용 사례의 경우, ``side_effect`` 는 함수가"
 " 될 수 있습니다. 이 함수는 mock과 같은 인자로 호출됩니다. 어떠한 함수 반환이든 간에 호출이 반환하는 것입니다.:"
 
-# TODO specification 논의
 #: ../Doc/library/unittest.mock-examples.rst:267
 msgid "Creating a Mock from an Existing Object"
 msgstr "기존 객체에서 mock 생성하기"
@@ -611,7 +607,6 @@ msgstr ""
 ":class:`datetime.date` 를 전역으로 패치하지 않고, *사용* 하려는 모듈에서 ``date`` 를 패치합니다. "
 ":ref:`where to patch <where-to-patch>` 를 참고하세요."
 
-# TODO (2019. 5) 안티 패턴 해석 어색
 #: ../Doc/library/unittest.mock-examples.rst:551
 msgid ""
 "When ``date.today()`` is called a known date is returned, but calls to "
@@ -761,7 +756,6 @@ msgstr ""
 ":func:`patch` 데코레이터는 실제 메서드를 만들어야 하는 mock 으로 메서드를 패치하는 것을 굉장히 간단하게 만들어 "
 "주었습니다."
 
-# TODO (2019. 5) under hood
 #: ../Doc/library/unittest.mock-examples.rst:678
 msgid ""
 "If you pass ``autospec=True`` to patch then it does the patching with a "
@@ -1142,7 +1136,6 @@ msgstr "이것은 ``from module import name`` 형식에서도 작동합니다.:"
 msgid "With slightly more work you can also mock package imports:"
 msgstr "약간 더 많은 작업을 통해 패키지 임포트를 mock 할 수 있습니다.:"
 
-# TODO (2019. 5) less verbose
 #: ../Doc/library/unittest.mock-examples.rst:1111
 msgid "Tracking order of calls and less verbose call assertions"
 msgstr "호출 순서와 적은 추가 정보 호출 어써션 추적하기"

--- a/library/unittest.mock-examples.po
+++ b/library/unittest.mock-examples.po
@@ -8,10 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-25 10:27+0900\n"
+"POT-Creation-Date: 2019-05-13 22:32+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Last-Translator: KaHee, Yu <yuygh131@gmail.com>\n"
+"Language-Team: Korean (https://python.flowdas.com)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,40 +19,40 @@ msgstr ""
 
 #: ../Doc/library/unittest.mock-examples.rst:2
 msgid ":mod:`unittest.mock` --- getting started"
-msgstr ""
+msgstr ":mod:`unittest.mock` --- 시작하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:13
 msgid "Using Mock"
-msgstr ""
+msgstr "Mock 사용하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:16
 msgid "Mock Patching Methods"
-msgstr ""
+msgstr "Mock Patching 메서드"
 
 #: ../Doc/library/unittest.mock-examples.rst:18
 msgid "Common uses for :class:`Mock` objects include:"
-msgstr ""
+msgstr ":class:`Mock` 객체의 일반적인 사용은 다음과 같습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:20
 msgid "Patching methods"
-msgstr ""
+msgstr "Patching 메서드"
 
 #: ../Doc/library/unittest.mock-examples.rst:21
 msgid "Recording method calls on objects"
-msgstr ""
+msgstr "객체에 대한 메서드 호출 기록"
 
 #: ../Doc/library/unittest.mock-examples.rst:23
 msgid ""
 "You might want to replace a method on an object to check that it is "
 "called with the correct arguments by another part of the system:"
-msgstr ""
+msgstr "객체의 메서드를 대체하여 시스템의 다른 부분에서 올바른 인수로 호출되었는지 확인할 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:31
 msgid ""
 "Once our mock has been used (``real.method`` in this example) it has "
 "methods and attributes that allow you to make assertions about how it has"
 " been used."
-msgstr ""
+msgstr "우선 mock (이 예제의 ``real.method`` )을 사용하면 메서드와 속성이 어떻게 사용되었는지에 대해 어써션 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:36
 msgid ""
@@ -60,24 +60,31 @@ msgid ""
 "classes are interchangeable. As the ``MagicMock`` is the more capable "
 "class it makes a sensible one to use by default."
 msgstr ""
+"대부분의 예제에서 :class:`Mock` 과 :class:`MagicMock` 클래스들은 서로 바꿔 사용할 수 있습니다. "
+"``MagicMock`` 은 좀 더 유능한 클래스이므로, 기본으로 사용할 수 있는 합리적인 클래스입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:40
 msgid ""
 "Once the mock has been called its :attr:`~Mock.called` attribute is set "
 "to ``True``. More importantly we can use the "
 ":meth:`~Mock.assert_called_with` or :meth:`~Mock.assert_called_once_with`"
-" method to check that it was called with the correct arguments."
+"  method to check that it was called with the correct arguments."
 msgstr ""
+"mock이 호출되면 :attr:`~Mock.called` 속성은 ``True`` 로 설정됩니다. 더 중요한 건, "
+":meth:`~Mock.assert_called_with` 또는 :meth:`~Mock.assert_called_once_with`"
+" 메서드를 사용하여 올바른 인자로 호출되었는지 확인할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:45
 msgid ""
 "This example tests that calling ``ProductionClass().method`` results in a"
 " call to the ``something`` method:"
 msgstr ""
+"이 예제는 ``ProductionClass().method`` 를 호출하면, ``something`` 메서드를 호출하는지 "
+"테스트합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:62
 msgid "Mock for Method Calls on an Object"
-msgstr ""
+msgstr "객체에 대한 메서드 호출 Mock하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:64
 msgid ""
@@ -86,18 +93,22 @@ msgid ""
 "object into a method (or some part of the system under test) and then "
 "check that it is used in the correct way."
 msgstr ""
+"지난 예제에서 우리는 객체에 대한 메서드를 직접 패치하여 올바르게 호출되었는지 확인했습니다. 또 다른 일반적인 사용 사례는 메서드 "
+"(혹은 시스템 일부의 테스트)에 객체를 전달한 다음, 올바른 방법으로 사용되는지 확인하는 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:69
 msgid ""
 "The simple ``ProductionClass`` below has a ``closer`` method. If it is "
 "called with an object then it calls ``close`` on it."
 msgstr ""
+"아래의 간단한 ``ProductionClass`` 는 ``closer`` 메서드를 가지고 있습니다. 이 객체와 함께 호출된 경우, "
+"``close`` 를 호출합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:77
 msgid ""
 "So to test it we need to pass in an object with a ``close`` method and "
 "check that it was called correctly."
-msgstr ""
+msgstr "따라서 이를 테스트하기 위해선 ``close`` 메서드를 사용하여 객체를 전달하고 올바르게 호출되었는지 확인해야 합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:85
 msgid ""
@@ -106,11 +117,16 @@ msgid ""
 "then accessing it in the test will create it, but "
 ":meth:`~Mock.assert_called_with` will raise a failure exception."
 msgstr ""
+"우리는 mock에 'close' 메서드를 제공하기 위해 어떠한 노력도 하지 않아도 됩니다. close에 접근하면, 해당 메서드가 "
+"생성됩니다. 따라서 'close'가 아직 호출되지 않았다면, 테스트에서 접근하면 생성되지만, "
+":meth:`~Mock.assert_called_with` 는 실패 예외를 발생시킵니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:92
 msgid "Mocking Classes"
-msgstr ""
+msgstr "Mocking 클래스"
 
+# TODO (2019. 5) mock out, mocked 해석 어색
+# https://en.wiktionary.org/wiki/mock_out
 #: ../Doc/library/unittest.mock-examples.rst:94
 msgid ""
 "A common use case is to mock out classes instantiated by your code under "
@@ -118,8 +134,11 @@ msgid ""
 "Instances are created by *calling the class*. This means you access the "
 "\"mock instance\" by looking at the return value of the mocked class."
 msgstr ""
+"일반적인 사용 사례는 테스트 중인 코드에서 인스턴스화된 클래스를 mock으로 대체하는 것입니다. 클래스를 패치할 때, 그 클래스는 "
+"mock으로 대체됩니다. 인스턴스는 *클래스를 호출* 하여 생성됩니다. 즉, mock된 클래스의 반환 값을 보고 \"mock "
+"인스턴스\" 에 접근한다는 것을 의미합니다."
 
-#: ../Doc/library/unittest.mock-examples.rst:99
+#: ../Doc/library/unittest.`mock-examples.rst:99
 msgid ""
 "In the example below we have a function ``some_function`` that "
 "instantiates ``Foo`` and calls a method on it. The call to :func:`patch` "
@@ -127,10 +146,13 @@ msgid ""
 "result of calling the mock, so it is configured by modifying the mock "
 ":attr:`~Mock.return_value`."
 msgstr ""
+"아래 예제에서, ``Foo`` 를 인스턴스화하고 메서드를 호출하는 ``some_function`` 함수가 있습니다. "
+":func:`patch` 를 호출하면, 클래스 ``Foo`` 가 mock으로 대체됩니다. ``Foo`` 인스턴스는 mock을 호출한"
+" 결과로서 mock의 :attr:`~Mock.return_value` 를 수정하여 구성됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:116
 msgid "Naming your mocks"
-msgstr ""
+msgstr "mock 이름 짓기"
 
 #: ../Doc/library/unittest.mock-examples.rst:118
 msgid ""
@@ -139,10 +161,12 @@ msgid ""
 "messages. The name is also propagated to attributes or methods of the "
 "mock:"
 msgstr ""
+"mock 이름을 붙이는 것은 유용할 수 있습니다. 이름은 mock의 repr에 표시되며 테스트 실패 메시지에 mock이 표시될 때 "
+"도움이 될 수 있습니다. 또한, 이름은 mock의 속성이나 메서드에도 전달됩니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:130
 msgid "Tracking all Calls"
-msgstr ""
+msgstr "모든 호출 추적하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:132
 msgid ""
@@ -150,7 +174,10 @@ msgid ""
 ":attr:`~Mock.mock_calls` attribute records all calls to child attributes "
 "of the mock - and also to their children."
 msgstr ""
+"종종 메서드에 대한 단일 호출 이상을 추적하려고 합니다. :attr:`~Mock.mock_calls` 속성은 모든 mock의 자식 "
+"속성 (또는 그들의 자식 속성에) 대한 호출 기록합니다."
 
+# TODO (2019. 5) assertion 해석 어색
 #: ../Doc/library/unittest.mock-examples.rst:144
 msgid ""
 "If you make an assertion about ``mock_calls`` and any unexpected methods "
@@ -159,12 +186,14 @@ msgid ""
 "also checking that they were made in the right order and with no "
 "additional calls:"
 msgstr ""
+"만약 ``mock_calls`` 에 대해 어써션 할때, 예상치 못한 메서드가 호출된 경우, 그 어써션는 실패합니다. 이는 예상된 "
+"호출에 대한 확인뿐만 아니라, 올바른 순서로 추가적인 호출 없이 이루어졌는지 확인하기 때문에 유용합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:149
 msgid ""
 "You use the :data:`call` object to construct lists for comparing with "
 "``mock_calls``:"
-msgstr ""
+msgstr "``mock_calls`` 과 비교하기 위한 리스트를 구성하기 위해 :data:`call` 객체를 사용합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:156
 msgid ""
@@ -172,26 +201,28 @@ msgid ""
 "means it is not possible to track nested calls where the parameters used "
 "to create ancestors are important:"
 msgstr ""
+"그러나 mock을 반환하는 호출에 대한 매개 변수는 기록되지 않습니다. 따라서 조상을 만드는 데 사용된 매개 변수가 중요한 중첩 "
+"호출을 추적하는 것은 불가능합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:167
 msgid "Setting Return Values and Attributes"
-msgstr ""
+msgstr "반환 값과 속성 설정하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:169
 msgid "Setting the return values on a mock object is trivially easy:"
-msgstr ""
+msgstr "mock 객체에서 반환 값을 설정하기는 쉽습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:176
 msgid "Of course you can do the same for methods on the mock:"
-msgstr ""
+msgstr "물론 mock 메서드에서도 같은 설정을 할 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:183
 msgid "The return value can also be set in the constructor:"
-msgstr ""
+msgstr "반환 값은 생성자에서도 설정할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:189
 msgid "If you need an attribute setting on your mock, just do it:"
-msgstr ""
+msgstr "만약 mock에서 속성 설정이 필요한 경우, 바로 설정하시면 됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:196
 msgid ""
@@ -200,22 +231,24 @@ msgid ""
 "call to return a list, then we have to configure the result of the nested"
 " call."
 msgstr ""
+"``mock.connection.cursor().execute(\"SELECT 1\")`` 같은 예제처럼 때로는 좀 더 복잡한 "
+"상황을 목업(mockup) 하고 싶을 때가 있습니다. 만약 이 호출을 리스트로 반환하려면, 중첩 호출의 결과를 구성해야 합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:200
 msgid ""
 "We can use :data:`call` to construct the set of calls in a \"chained "
 "call\" like this for easy assertion afterwards:"
-msgstr ""
+msgstr ":data:`call` 를 사용하여 나중에 쉽게 어써션하기위해, \"연결된 호출\" 에서 호출 집합을 구성할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:214
 msgid ""
 "It is the call to ``.call_list()`` that turns our call object into a list"
 " of calls representing the chained calls."
-msgstr ""
+msgstr "``.call_list()`` 를 호출하면, 호출 객체가 연결된 호출을 나타내는 호출 리스트로 바뀝니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:219
 msgid "Raising exceptions with mocks"
-msgstr ""
+msgstr "mock으로 예외 발생시키기"
 
 #: ../Doc/library/unittest.mock-examples.rst:221
 msgid ""
@@ -223,10 +256,12 @@ msgid ""
 "exception class or instance then the exception will be raised when the "
 "mock is called."
 msgstr ""
+"유용한 속성은 :attr:`~Mock.side_effect` 입니다. 만약 클래스 또는 인스턴스 예외를 설정하면 mock을 호출 "
+"했을 때, 예외가 발생됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:233
 msgid "Side effect functions and iterables"
-msgstr ""
+msgstr "부작용 함수와 이터러블"
 
 #: ../Doc/library/unittest.mock-examples.rst:235
 msgid ""
@@ -236,6 +271,9 @@ msgid ""
 "value. When you set ``side_effect`` to an iterable every call to the mock"
 " returns the next value from the iterable:"
 msgstr ""
+"``side_effect`` 역시 함수 혹은 이터러블로 설정할 수 있습니다. 이터러블로 ``side_effect`` 를 사용하는 "
+"사례는 mock이 여러 번 호출되는 곳이며, 호출마다다른 값을 반환하기 원하는 경우입니다. ``side_effect`` 를 "
+"이터러블로 설정하면, mock을 호출 할 때마다 다음 값을 반환합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:250
 msgid ""
@@ -244,10 +282,13 @@ msgid ""
 "function. The function will be called with the same arguments as the "
 "mock. Whatever the function returns is what the call returns:"
 msgstr ""
+"mock이 호출되는 것에 따라 반환 값이 동적으로 바뀌는 것과 같은 고급 사용 사례의 경우, ``side_effect`` 가 함수가"
+" 될 수 있습니다. 이 함수는 mock과 같은 인자로 호출됩니다. 어떠한 함수 반환이든 간에 호출이 반환하는 것입니다.:"
 
+# TODO specification 논의
 #: ../Doc/library/unittest.mock-examples.rst:267
 msgid "Creating a Mock from an Existing Object"
-msgstr ""
+msgstr "기존 객체에서 mock 생성하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:269
 msgid ""
@@ -259,6 +300,10 @@ msgid ""
 "longer has ``some_method`` - then your tests will continue to pass even "
 "though your code is now broken!"
 msgstr ""
+"과도한 mocking 사용의 한 가지 문제점은 실제 코드가 아닌 mock으로 구현된 테스트를 결합한다는 것입니다. "
+"``some_method`` 를 구현하는 클래스가 있다고 가정해 봅시다. *또한* 이 객체의 mock이 제공하는 "
+"``some_method`` 를  다른 클래스 테스트에서도 제공합니다.나중에 첫 번째 클래스를 리팩토링하여 "
+"``some_method`` 가 없어진 경우, 코드가 깨졌음에도 불구하고 테스트가 계속 통과될 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:276
 msgid ""
@@ -269,6 +314,9 @@ msgid ""
 " your specification, then tests that use that class will start failing "
 "immediately without you having to instantiate the class in those tests."
 msgstr ""
+":class:`Mock` 은 *spec* 키워드 인자를 사용하여 mock 객체를 정의할 수 있게 합니다. 정의된 mock 객체에 "
+"존재하지 않는 메서드 / 속성에 접근하면, 속성 오류가 즉시 발생합니다. 만약 정의을 변경하면, 해당 클래스를 사용하는 테스트는 "
+"해당 테스트에서 클래스를 인스턴스화하지 않고도 즉시 실패합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:289
 msgid ""
@@ -276,12 +324,16 @@ msgid ""
 "the mock, regardless of whether some parameters were passed as positional"
 " or named arguments::"
 msgstr ""
+"정의를 사용하면 일부 매개 변수가 위치 인자 또는 이름있는 인자로 전달되었는지에 대한 여부와 관계없이 mock에 대한 호출을 좀 더"
+" 똑똑하게 일치시킬 수 있습니다.::"
 
 #: ../Doc/library/unittest.mock-examples.rst:300
 msgid ""
 "If you want this smarter matching to also work with method calls on the "
 "mock, you can use :ref:`auto-speccing <auto-speccing>`."
 msgstr ""
+"만약 좀 더 똑똑한 매칭을 mock 메서드 호출과 함께 사용하려면, :ref:`auto-speccing <auto-"
+"speccing>` 사용하면 됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:303
 msgid ""
@@ -289,10 +341,12 @@ msgid ""
 " arbitrary attributes as well as the getting of them then you can use "
 "*spec_set* instead of *spec*."
 msgstr ""
+"만약 임의의 속성을 설정하는 것뿐만 아니라 설정하지 못하게 하는 더 강력한 규격을 원한다면, *spec* 대신 *spec_set* "
+"을 사용하면 됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:310
 msgid "Patch Decorators"
-msgstr ""
+msgstr "데코레이터 패치하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:314
 msgid ""
@@ -300,6 +354,8 @@ msgid ""
 "where they are looked up. This is normally straightforward, but for a "
 "quick guide read :ref:`where to patch <where-to-patch>`."
 msgstr ""
+":func:`patch` 를 사용하면 룩업된 네임스페이스의 객체들을 패치하는 것이 중요합니다. 이것은 일반적으로 간단하지만, 빠른 "
+"안내 위해 :ref:`where to patch <where-to-patch>` 를 참고하세요."
 
 #: ../Doc/library/unittest.mock-examples.rst:319
 msgid ""
@@ -309,6 +365,9 @@ msgid ""
 "global, so patching on them has to be undone after the test or the patch "
 "will persist into other tests and cause hard to diagnose problems."
 msgstr ""
+"테스트에서 공통으로 필요한 것은 클래스 속성 또는 모듈 속성을 패치하는 것입니다. 예를 들어, 모듈에 클래스를 내장하거나 패치하여 "
+"이것이 인스턴스화 되었는지 확인하는 테스트가 있습니다. 모듈과 클래스는 실제로 전역적이므로, 테스트가 끝난 후에는 패치를 풀어줘야 "
+"합니다. 그렇지 않은 경우, 패치가 다른 테스트에도 유지되어 문제를 판단하는데 어려질 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:325
 msgid ""
@@ -320,24 +379,30 @@ msgid ""
 "'patch.object' takes an object and the name of the attribute you would "
 "like patched, plus optionally the value to patch it with."
 msgstr ""
+"mock은 3가지 편리한 데코레이터를 제공합니다.: :func:`patch`, :func:`patch.object` 그리고 "
+":func:`patch.dict` ``patch`` 는 ``package.module.Class.attribute`` 형식의 단일 "
+"문자열을 이용하여, 패치 할 속성을 지정합니다. 또한 선택적으로 대체하고 싶은 속성 (또는 클래스 또는 아무거나) 값을 가질 수 "
+"있습니다. 'patch.object'는 객체와 패치 하고 싶은 속성의 이름, 그리고 패치할 값을 지정할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:333
 msgid "``patch.object``:"
-msgstr ""
+msgstr "``patch.object``:"
 
 #: ../Doc/library/unittest.mock-examples.rst:350
 msgid ""
 "If you are patching a module (including :mod:`builtins`) then use "
 ":func:`patch` instead of :func:`patch.object`:"
 msgstr ""
+"만약 모듈 (:mod:`builtins` 을 포함)을 패치하면, :func:`patch.object` 대신 :func:`patch`"
+" 를 사용하세요.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:360
 msgid "The module name can be 'dotted', in the form ``package.module`` if needed:"
-msgstr ""
+msgstr "필요한 경우 ``package.module`` 형식으로 모듈 이름을 '점'으로 구분 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:369
 msgid "A nice pattern is to actually decorate test methods themselves:"
-msgstr ""
+msgstr "좋은 패턴은 실제로 테스트 메서드 자체를 데코레이트 하는 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:380
 msgid ""
@@ -345,10 +410,12 @@ msgid ""
 " argument (or :func:`patch.object` with two arguments). The mock will be "
 "created for you and passed into the test function / method:"
 msgstr ""
+"Mock으로 패치 하고 싶다면, 하나의 인자 (혹은 두 개의 인자가 있는 :func:`patch.object` )와 함께 "
+":func:`patch` 를 사용할 수 있습니다. mock은 생성되어 테스트 함수 / 메서드로 전달됩니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:392
 msgid "You can stack up multiple patch decorators using this pattern:"
-msgstr ""
+msgstr "아래와 같은 패턴을 사용하여 여러 개의 패치 데코레이터를 계속 쌓을 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:403
 msgid ""
@@ -357,6 +424,9 @@ msgid ""
 "decorators are applied). This means from the bottom up, so in the example"
 " above the mock for ``test_module.ClassName2`` is passed in first."
 msgstr ""
+"패치 데코레이터를 중첩하여 사용할 때, mock은 데코레이터가 적용된 순서대로 (데코레이터가 적용된 일반적인 **파이썬** 순서) "
+"데코레이팅 된 함수에 전달됩니다. 즉, 위에서 아래로 적용되는 것을 의미합니다. 위의 예제에서 "
+"``test_module.ClassName2`` 가 먼저 mock에 전달됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:408
 msgid ""
@@ -364,18 +434,24 @@ msgid ""
 "during a scope and restoring the dictionary to its original state when "
 "the test ends:"
 msgstr ""
+"또한 범위 내에서 딕셔너리에 값을 설정하고, 테스트가 끝나면 딕셔너리를 원래 상태로 다시 되돌리는 :func:`patch.dict`"
+" 도 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:419
 msgid ""
 "``patch``, ``patch.object`` and ``patch.dict`` can all be used as context"
 " managers."
 msgstr ""
+"``patch``\\, ``patch.object`` 그리고 ``patch.dict``\\는 모두 컨텍스트 관리자로 사용할 수 "
+"있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:421
 msgid ""
 "Where you use :func:`patch` to create a mock for you, you can get a "
 "reference to the mock using the \"as\" form of the with statement:"
 msgstr ""
+"mock을 생성하기 위해 :func:`patch` 를 사용하는 경우, with 문에서 \"as\" 형식 사용하여 mock에 대한 "
+"참조를 얻을 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:436
 msgid ""
@@ -384,18 +460,21 @@ msgid ""
 "applying the decorator individually to every method whose name starts "
 "with \"test\"."
 msgstr ""
+"다른 ``patch`` 로, ``patch.object`` 그리고 ``patch.dict`` 를 클래스 데코레이터로 사용할 수 "
+"있습니다. 이 방법을 이용하는 경우, 이름이 \"test\"로 시작하는 모든 메서드에 개별적으로 데코레이터를 적용하는 것과 "
+"같습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:444
 msgid "Further Examples"
-msgstr ""
+msgstr "추가 예제"
 
 #: ../Doc/library/unittest.mock-examples.rst:447
 msgid "Here are some more examples for some slightly more advanced scenarios."
-msgstr ""
+msgstr "조금 더 고급스러운 시나리오에 대한 몇 가지 예시가 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:451
 msgid "Mocking chained calls"
-msgstr ""
+msgstr "연결 된 호출 Mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:453
 msgid ""
@@ -404,12 +483,16 @@ msgid ""
 "called for the first time, or you fetch its ``return_value`` before it "
 "has been called, a new :class:`Mock` is created."
 msgstr ""
+"연결된 호출은 :attr:`~Mock.return_value` 속성을 이해하고 나면, mock이 좀 더 간단해집니다. mock을 "
+"처음 호출하거나, 호출되기 전 ``return_value`` 를 패치하면 새로운 :class:`Mock` 이 생성됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:458
 msgid ""
 "This means that you can see how the object returned from a call to a "
 "mocked object has been used by interrogating the ``return_value`` mock:"
 msgstr ""
+"즉, mock 된 객체 호출에서 반환된 객체가 ``return_value`` mock을 통해 어떻게 사용되었는지 확인할 수 "
+"있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:466
 msgid ""
@@ -417,10 +500,12 @@ msgid ""
 " chained calls. Of course another alternative is writing your code in a "
 "more testable way in the first place..."
 msgstr ""
+"여기에서 연결된 호출에 대해 구성한 뒤, 어써션을 수행하는 간단한 일입니다. 물론 다른 대안은 처음부터 코드를 좀 더 테스트 가능한"
+" 방식으로 작성하는 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:470
 msgid "So, suppose we have some code that looks a little bit like this:"
-msgstr ""
+msgstr "따라서 우리는 이 코드와 비슷한 코드를 가지고 있다고 가정해 봅시다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:479
 msgid ""
@@ -428,6 +513,8 @@ msgid ""
 "``method()``? Specifically, we want to test that the code section ``# "
 "more code`` uses the response object in the correct way."
 msgstr ""
+"``BackendProvider``\\의 테스트가 이미 잘 되었다고 가정하면, ``method()`` 를 테스트하는 방법은 "
+"무엇일까요? 특히 코드 섹션 ``# more code`` 가 응답 객체를 올바른 방법으로 사용하는지 테스트하고 싶습니다. "
 
 #: ../Doc/library/unittest.mock-examples.rst:483
 msgid ""
@@ -438,6 +525,10 @@ msgid ""
 "assume the object it returns is 'file-like', so we'll ensure that our "
 "response object uses the builtin :func:`open` as its ``spec``."
 msgstr ""
+"``Something`` 인스턴스에 ``backend`` 속성을 몽키패치(Monkey Patch) 할 수 있는 인스턴스 속성으로부터"
+" 호출의 연결이 생성됩니다. 이러한 특별 케이스에서는 ``start_call``\\에 대한 최종 호출의 반환 값에만 관심이 있기 "
+"때문에 많은 구성이 필요하지 않습니다.반환하는 객체가 '파일형'이라고 가정하고, 응답 객체를 내장된 :func:`open` 을 "
+"``spec`` 로 사용하도록 할 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:490
 msgid ""
@@ -445,6 +536,8 @@ msgid ""
 "mock response object for it. To set the response as the return value for "
 "that final ``start_call`` we could do this::"
 msgstr ""
+"이를 위해 mock 백엔드로서 mock 인스턴스를 생성하고 이를 위한 mock 응답을 생성합니다. 마지막 ``start_call``"
+" 에 대한 응답을 반환 값으로 설정하기 위해선, 다음을 수행해야 합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:496
 msgid ""
@@ -452,12 +545,14 @@ msgid ""
 ":meth:`~Mock.configure_mock` method to directly set the return value for "
 "us:"
 msgstr ""
+":meth:`~Mock.configure_mock` 메서드를 사용하여 우리가 반환 값을 직접 설정하는 방식을 이용하여 좀 더 좋게 "
+"할 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:505
 msgid ""
 "With these we monkey patch the \"mock backend\" in place and can make the"
 " real call:"
-msgstr ""
+msgstr "이러한 \"mock backend\" 에서 몽키패치(Monkey Patch)하고 실제 호출을 만들 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:511
 msgid ""
@@ -466,10 +561,13 @@ msgid ""
 "there will be several entries in ``mock_calls``. We can use "
 ":meth:`call.call_list` to create this list of calls for us:"
 msgstr ""
+":attr:`~Mock.mock_calls` 을 이용하여 연결된 호출을 단일 어서트로 확인 할 수 있습니다. 체인 된 호출은 한 "
+"줄의 코드에서 여러번 호출되기 때문에, ``mock_calls`` 에 여러 속성들이 있습니다. "
+":meth:`call.call_list` 를 이용해서, 호출 목록을 만들 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:522
 msgid "Partial mocking"
-msgstr ""
+msgstr "부분 Mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:524
 msgid ""
@@ -479,6 +577,9 @@ msgid ""
 "written in C, and so I couldn't just monkey-patch out the static "
 ":meth:`date.today` method."
 msgstr ""
+"일부 테스트에서 :meth:`datetime.date.today` 호출을 대체하여 알려진 날짜를 반환하고 싶었지만, 테스트 중인 "
+"코드가 새 날짜 객체를 못 만들게 하고 싶지는 않았습니다. 아쉽게도, :class:`datetime.date` 는 C로 작성되었기 "
+"때문에, 정적 :meth:`date.today` 메서드를 몽키패치 할 수 없습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:529
 msgid ""
@@ -486,6 +587,8 @@ msgid ""
 " date class with a mock, but passing through calls to the constructor to "
 "the real class (and returning real instances)."
 msgstr ""
+"mock을 사용하여 날짜 클래스를 효과적으로 랩핑하는 것과 관련된 간단한 방법을 찾았지만, 생성자 호출을 실제 클래스 (그리고 실제"
+" 인스턴스)로 전달했습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:533
 msgid ""
@@ -495,6 +598,9 @@ msgid ""
 "date. When the mock date class is called a real date will be constructed "
 "and returned by ``side_effect``."
 msgstr ""
+":func:`patch decorator <patch>` 는 테스트 중인 모듈에서 ``date`` 클래스를 대체하는 데 사용됩니다."
+" 날짜 클래스 mock 에서 :attr:`side_effect` 속성은 실제 날짜를 반환하는 람다 함수로 설정했습니다. 날짜 클래스"
+" mock이 호출 될 때, 실제 날짜는 생성되고 ``side_effect`` 에 의해 반환됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:548
 msgid ""
@@ -502,7 +608,10 @@ msgid ""
 "``date`` in the module that *uses* it. See :ref:`where to patch <where-"
 "to-patch>`."
 msgstr ""
+":class:`datetime.date` 를 전역적으로 패치하지 않고, *사용* 하려는 모듈에서 ``date`` 를 패치합니다. "
+":ref:`where to patch <where-to-patch>` 를 참고하세요."
 
+# TODO (2019. 5) 안티 패턴 해석 어색
 #: ../Doc/library/unittest.mock-examples.rst:551
 msgid ""
 "When ``date.today()`` is called a known date is returned, but calls to "
@@ -511,6 +620,9 @@ msgid ""
 "the same algorithm as the code under test, which is a classic testing "
 "anti-pattern."
 msgstr ""
+"``date.today()``\\가 호출 되면, 알려진 날짜가 반환되지만, ``date(...)`` 생성자는 여전히 정상 날짜를 "
+"호출합니다. 이것이 없다면 고전적인 안티 패턴 테스트인 테스트 중인 코드와 같은 알고리즘을 사용하여 예상 결과를계산해야 한다는 것을"
+" 알 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:556
 msgid ""
@@ -518,6 +630,8 @@ msgid ""
 "attributes (``call_count`` and friends) which may also be useful for your"
 " tests."
 msgstr ""
+"날짜 생성자에 대한 호출은 테스트에 유용할 수 있는 ``mock_date`` 속성 (``call_count`` 그리고 친구들)에 "
+"기록됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:559
 msgid ""
@@ -526,16 +640,21 @@ msgid ""
 "<https://williambert.online/2011/07/how-to-unit-testing-in-django-with-"
 "mocking-and-patching/>`_."
 msgstr ""
+"mocking 날짜 또는 내장된 클래스를 다루는 다른 방법은, `이 블로그 엔트리 "
+"<https://williambert.online/2011/07/how-to-unit-testing-in-django-with-"
+"mocking-and-patching/>`_ 를 참고하세요."
 
 #: ../Doc/library/unittest.mock-examples.rst:565
 msgid "Mocking a Generator Method"
-msgstr ""
+msgstr "제너레이터 메서드 Mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:567
 msgid ""
 "A Python generator is a function or method that uses the :keyword:`yield`"
 " statement to return a series of values when iterated over [#]_."
 msgstr ""
+"파이썬 제너레이터는 [#]_ 를 반복 할 때 :keyword:`yield` 문을 사용하여 일련의 값들을 반환하는 함수 혹은 메서드 "
+"입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:570
 msgid ""
@@ -544,16 +663,19 @@ msgid ""
 "method for iteration is :meth:`~container.__iter__`, so we can mock this "
 "using a :class:`MagicMock`."
 msgstr ""
+"제너레이터 메서드 / 함수는 제너레이터 객체를 반환하기 위해 호출됩니다. 제너레이터 객체는 반복되는 객체입니다. 이터레이션 메서드의"
+" 프로토콜은 :meth:`~container.__iter__` 입니다. 따라서 우리는 :class:`MagicMock` 을 이용하여"
+" mock 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:575
 msgid ""
 "Here's an example class with an \"iter\" method implemented as a "
 "generator:"
-msgstr ""
+msgstr "다음은 \"iter\" 메서드가 제너레이터로 구현 된 예제 클래스 입니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:587
 msgid "How would we mock this class, and in particular its \"iter\" method?"
-msgstr ""
+msgstr "어떻게 이 클래스와 \"iter\" 메서드를 mock 할 수 있을까요?"
 
 #: ../Doc/library/unittest.mock-examples.rst:589
 msgid ""
@@ -561,6 +683,8 @@ msgid ""
 " to :class:`list`), we need to configure the object returned by the call "
 "to ``foo.iter()``."
 msgstr ""
+"이터레이션 (암시적으론 :class:`list` 호출)에서 반환된 값을 구성하기 위해선, ``foo.iter()`` 를 호출하여 "
+"반환된 객체를 구성해야 합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:597
 msgid ""
@@ -570,10 +694,14 @@ msgid ""
 "and how powerful they are is: `Generator Tricks for Systems Programmers "
 "<http://www.dabeaz.com/generators/>`_."
 msgstr ""
+"제너레이터의 표현식과 좀 더 `고급스러운 사용법 "
+"<http://www.dabeaz.com/coroutines/index.html>`_ 은 여기에서는 언급하지 않겠습니다. "
+"제너레이터에 대한 매우 훌륭한 입문서와 발전 방법은: `Generator Tricks for Systems Programmers "
+"<http://www.dabeaz.com/generators/>`_ 를 참고하세요."
 
 #: ../Doc/library/unittest.mock-examples.rst:605
 msgid "Applying the same patch to every test method"
-msgstr ""
+msgstr "모든 테스트 메서드에 동일한 패치 적용하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:607
 msgid ""
@@ -584,6 +712,10 @@ msgid ""
 "applies the patches to all test methods on the class. A test method is "
 "identified by methods whose names start with ``test``:"
 msgstr ""
+"여러 테스트 방법을 위해 다양한 패치를 원한다면, 모든 메서드에 패치 데코레이터를 적용하는 것이 좋습니다. 이것은 불필요한 반복처럼"
+" 느껴질 수도 있습니다. 파이썬 2.6 이상에서는 :func:`patch` 를 (다양한 형태로) 클래스 데코레이터로 사용 할 수 "
+"있습니다. 이렇게 함으로써 클래스의 모든 테스트 메서드에 패치가 적용됩니다. 테스트 메서드는 메서드 이름이 ``test`` 로 "
+"시작하는 것으로 식별됩니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:631
 msgid ""
@@ -591,6 +723,8 @@ msgid ""
 "stop`. These allow you to move the patching into your ``setUp`` and "
 "``tearDown`` methods."
 msgstr ""
+"패치를 관리하는 다른 방법은 :ref:`start-and-stop` 을 사용하는 것입니다. 이를 통해 패치를 ``setUp`` "
+"메서드와 ``tearDown`` 메서드로 이동 시킬 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:647
 msgid ""
@@ -599,10 +733,13 @@ msgid ""
 "if an exception is raised in the setUp then tearDown is not called. "
 ":meth:`unittest.TestCase.addCleanup` makes this easier:"
 msgstr ""
+"이 방법을 사용하는 경우엔 반드시 ``stop`` 호출하여 패치를 \"실행 취소\" 시켜야 합니다. 이것은 setUp에서 예외가 "
+"발생하면 tearDown이 호출되지 않기 때문에, 생각보다 번거로울 수 있습니다. "
+":meth:`unittest.TestCase.addCleanup` 을 사용하면 좀 더 쉬워집니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:665
 msgid "Mocking Unbound Methods"
-msgstr ""
+msgstr "언 바운드 메서드 Mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:667
 msgid ""
@@ -617,7 +754,14 @@ msgid ""
 ":func:`patch` decorator makes it so simple to patch out methods with a "
 "mock that having to create a real function becomes a nuisance."
 msgstr ""
+"저는 테스트를 작성하는 동안 *언 바운드 메서드* (인스턴스가 아닌 클래스에 메서드 패치)를 패치해야했습니다. 이 특정 메서드를 "
+"호출하는 객체가 무엇인지 어서트하고 싶었기 때문에, 첫번째 인자로 전달되어야 했습니다. 문제는 mock으로 이 메서드를 패치 할 수"
+" 없다는 것입니다. 왜냐하면 언 바운드 메서드를 mock 객체로 대체하면 인스턴스에서 가져올 때 바운드 메서드가 되지 않아서 "
+"자체적으로 전달되지 않기 때문입니다. 해결 방법은 언 바운드 메서드를 대신해서 실제 메서드를 패치하는 것입니다. "
+":func:`patch` 데코레이터는 실제 메서드를 만들어야 하는 mock 으로 메서드를 패치하는 것을 굉장히 간단하게 만들어 "
+"주었습니다."
 
+# TODO (2019. 5) under hood
 #: ../Doc/library/unittest.mock-examples.rst:678
 msgid ""
 "If you pass ``autospec=True`` to patch then it does the patching with a "
@@ -629,22 +773,28 @@ msgid ""
 "fetched from an instance. It will have ``self`` passed in as the first "
 "argument, which is exactly what I wanted:"
 msgstr ""
+"``autospec=True``\\를 패치 옵션으로 설정하면, *실제* 메서드 객체로 패치합니다. 이 함수 객체는 대체할 시그니처와"
+" 동일한 시그니처를 갖지만, 후드(hood) 부분은 mock에 위임합니다. 이전과 같은 방법으로 mock이 자동으로 생성됩니다. "
+"클래스에서 언 바운드 메소드를 패치하기 위해, mock 된 함수는 인스턴스에서 가져온다면 바운드 메서드로 변환되는 의미입니다. 첫 "
+"번재 인자로 ``self`` 를 전달할 것이고, 이것은 제가 원했던 것입니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:699
 msgid ""
 "If we don't use ``autospec=True`` then the unbound method is patched out "
 "with a Mock instance instead, and isn't called with ``self``."
 msgstr ""
+"만약 ``autospec=True`` 를 사용하지 않았다면, 언 바운드 메소드는 Mock 인스턴스로 대신 패치되고, ``self``"
+" 는 호출되지 않습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:704
 msgid "Checking multiple calls with mock"
-msgstr ""
+msgstr "mock 으로 여러 호출 확인하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:706
 msgid ""
 "mock has a nice API for making assertions about how your mock objects are"
 " used."
-msgstr ""
+msgstr "mock에는 mock 객체 사용 방법에 대한 어설션을 만들기 위한 좋은 API가 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:713
 msgid ""
@@ -652,6 +802,8 @@ msgid ""
 ":meth:`assert_called_once_with` method that also asserts that the "
 ":attr:`call_count` is one."
 msgstr ""
+"mock 이 한 번만 호출 되었다면, :meth:`assert_called_once_with` 메소드를 사용할 수 있습니다. 이 "
+"메서드는 또한 :attr:`call_count` 가 1이라고 어서트합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:724
 msgid ""
@@ -660,6 +812,9 @@ msgid ""
 "called several times, and you want to make assertions about *all* those "
 "calls you can use :attr:`~Mock.call_args_list`:"
 msgstr ""
+"``assert_called_with`` 과 ``assert_called_once_with`` 모두 *가장 최근* 에 호출 되었다는"
+" 것을 어써션합니다. mock을 여러번 호출 했을 경우, *모든* 호출에 대해 어써션 하고 싶다면 "
+":attr:`~Mock.call_args_list`: 를 사용할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:736
 msgid ""
@@ -668,10 +823,12 @@ msgid ""
 "``call_args_list``. This looks remarkably similar to the repr of the "
 "``call_args_list``:"
 msgstr ""
+":data:`call` 도우미는 이러한 호출에 대한 어써션을 쉽게 만듭니다. 예상되는 호출 목록을 작성하여 "
+"``call_args_list`` 와 비교할 수 있습니다. ``call_args_list``의 repr 과 매우 유사해 보입니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:746
 msgid "Coping with mutable arguments"
-msgstr ""
+msgstr "가변 인자 복사하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:748
 msgid ""
@@ -681,18 +838,21 @@ msgid ""
 "under test then you can no longer make assertions about what the values "
 "were when the mock was called."
 msgstr ""
+"이러한 상환은 드물지만, mock이 가변 인자로 호출 될 때 발생 할 수도 있습니다. ``call_args`` 그리고 "
+"``call_args_list`` 는 인자에 대한 *참조*\\를 저장합니다. 인자가 테스트 중인 코드에 의해 변경되면, 더 이상 "
+"mock이 호출 되었을 때 값에 대한 어서션을 만들 수 없습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:753
 msgid ""
 "Here's some example code that shows the problem. Imagine the following "
 "functions defined in 'mymodule'::"
-msgstr ""
+msgstr "이러한 문제를 보여주는 몇 가지 예제 코드가 있습니다. 'mymodule': 에 정의 된 다음 함수를 상상해보십시오.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:764
 msgid ""
 "When we try to test that ``grob`` calls ``frob`` with the correct "
 "argument look what happens:"
-msgstr ""
+msgstr "우리가 ``grob`` 호출을 테스트하려고 할 때, 올바른 인자를 가진 ``frob``\\는 어떻게 되는지 보여줍니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:779
 msgid ""
@@ -700,6 +860,8 @@ msgid ""
 " could then cause problems if you do assertions that rely on object "
 "identity for equality."
 msgstr ""
+"하나의 가능성은 우리가 전달한 어서션을 mock이 복사하는 것입니다. 만약 동등성을 위해 객체의 동일성에 의존하는 어서션을 수행하면"
+" 문제가 발생 할 수도 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:783
 msgid ""
@@ -711,6 +873,10 @@ msgid ""
 "can use the mock methods for doing the assertion. Again a helper function"
 " sets this up for me."
 msgstr ""
+":attr:`side_effect` 기능을 사용하는 한 가지 해결책이 있습니다. 만약 mock 에 ``side_effect`` "
+"함수를 제공하면, ``side_effect`` 는 mock 객체와 동일한 args로 호출됩니다. 이것은 인자를 복사하고 나중에 "
+"어서션을 위해 저장할 수 있는 기회를 줍니다. 이 예제에서 인자를 저장하기 위해 *또 다른* mock을 사용하고 있기 때문에, "
+"어서션을 하기 위해 mock 메서드를 사용 할 수 있습니다. 다시 한 번 도우미 함수가 이것을 설정합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:812
 msgid ""
@@ -719,6 +885,8 @@ msgid ""
 "function makes a copy of the args and calls our ``new_mock`` with the "
 "copy."
 msgstr ""
+"``copy_call_args`` mock이 호출 될 때 호출됩니다. 이것은 우리가 어서션할 새로운 mock을 반환합니다. "
+"``side_effect`` 함수는 args 의 사본을 만들고 ``new_mock``을 사본으로 호출합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:818
 msgid ""
@@ -726,6 +894,8 @@ msgid ""
 "checking arguments at the point they are called. You can simply do the "
 "checking inside a ``side_effect`` function."
 msgstr ""
+"mock을 한 번 사용하게 되면, 인자가 호출 되는 시점에서 인자를 확인하는 더 쉬운 방법이 있습니다. ``side_effect` "
+"함수 내에서 간단히 검사를 할 수 있습니다. "
 
 #: ../Doc/library/unittest.mock-examples.rst:832
 msgid ""
@@ -733,6 +903,8 @@ msgid ""
 ":class:`MagicMock` that copies (using :func:`copy.deepcopy`) the "
 "arguments. Here's an example implementation:"
 msgstr ""
+"또 다른 방법은 인자를 (:func:`copy.deepcopy` 를 사용한) 복사하여 :class:`Mock` 또는 "
+":class:`MagicMock` 의 하위 클래스를 만드는 것입니다. 다음은 구현 예시입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:856
 msgid ""
@@ -741,10 +913,13 @@ msgid ""
 "automatically. That means all children of a ``CopyingMock`` will also "
 "have the type ``CopyingMock``."
 msgstr ""
+"``Mock`` 또는 ``MagicMock`` 를 서브 클래스로 만들 때, 동적으로 생성된 모든 속성이 있고, "
+"``return_value`` 는 서브 클래스를 자동으로 사용합니다. ``CopyingMock`` 의 모든 자식들은 "
+"``CopyingMock`` 을 가지고 있다는 의미힙니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:862
 msgid "Nesting Patches"
-msgstr ""
+msgstr "중첩 패치"
 
 #: ../Doc/library/unittest.mock-examples.rst:864
 msgid ""
@@ -752,6 +927,8 @@ msgid ""
 "you can end up with nested with statements indenting further and further "
 "to the right:"
 msgstr ""
+"컨텍스트 관리자로 패치를 사용하는 것은 좋지만, 여러 패치를 수행하면계속해서 오른쪽으로 들여쓰기가 되는 문장으로 중첩 될 수 "
+"있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:882
 msgid ""
@@ -760,16 +937,18 @@ msgid ""
 "method, ``create_patch``, puts the patch in place and returns the created"
 " mock for us:"
 msgstr ""
+"`cleanup`` 함수와 :ref:`start-and-stop` 는 중첩 된 들여쓰기 없이 동일한 효과를 얻을 수 있습니다.간단한"
+" 도우미 메소드인 ``create_patch`` 가 패치하고 생성된 mock을 반환합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:910
 msgid "Mocking a dictionary with MagicMock"
-msgstr ""
+msgstr "MagicMock으로 딕셔너리 mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:912
 msgid ""
 "You may want to mock a dictionary, or other container object, recording "
 "all access to it whilst having it still behave like a dictionary."
-msgstr ""
+msgstr "딕셔너리 또는 다른 컨테이너 객체를 mock을 원한다면, 딕셔너리처럼 작동하는 동안 모든 접근을 기록할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:915
 msgid ""
@@ -777,6 +956,8 @@ msgid ""
 "dictionary, and using :data:`~Mock.side_effect` to delegate dictionary "
 "access to a real underlying dictionary that is under our control."
 msgstr ""
+"(딕셔너리 처럼 행동하는) :class:`MagicMock` 와 :data:`~Mock.side_effect` 를 사용하여 우리가 "
+"제어하고 있는 실제 딕셔너리에 딕셔너리 접근권을 위임 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:919
 msgid ""
@@ -785,18 +966,25 @@ msgid ""
 "is called with the key (and in the case of ``__setitem__`` the value "
 "too). We can also control what is returned."
 msgstr ""
+"``MagicMock`` 의  :meth:`__getitem__` 와 :meth:`__setitem__` 메서드가 호출 되면, "
+"(일반 딕셔너리 접근권) ``side_effect`` 가 키와 함께 호출됩니다. ( ``__setitem__`` 경우에는 값도) "
+"우리는 반환되는 것 또한 제어 할 수 있습니다. "
 
 #: ../Doc/library/unittest.mock-examples.rst:923
 msgid ""
 "After the ``MagicMock`` has been used we can use attributes like "
 ":data:`~Mock.call_args_list` to assert about how the dictionary was used:"
 msgstr ""
+"``MagicMock`` 가 사용 된 후에는 :data:`~Mock.call_args_list` 와 같은 속성을 사용하여딕셔너리가 "
+"어떻게 사용되었는지 어서트 할 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:939
 msgid ""
 "An alternative to using ``MagicMock`` is to use ``Mock`` and *only* "
 "provide the magic methods you specifically want:"
 msgstr ""
+"``MagicMock``을 사용하는 대신, ``Mock`` 을 사용하여 *오직* 특별히 원하는 magic 메서드만 제공 할 수 "
+"있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:946
 msgid ""
@@ -804,6 +992,8 @@ msgid ""
 "*spec* (or *spec_set*) argument so that the ``MagicMock`` created only "
 "has dictionary magic methods available:"
 msgstr ""
+"*세 번째* 옵션은 ``MagicMock`` 을 사용하지만, ``dict`` 을 *spec* (또는 *spec_set*//) 인자로"
+" 전달하여 ``MagicMock`` 에서 만든 딕셔너리 magic 메서드만 사용 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:954
 msgid ""
@@ -811,22 +1001,26 @@ msgid ""
 "a normal dictionary but recording the access. It even raises a "
 ":exc:`KeyError` if you try to access a key that doesn't exist."
 msgstr ""
+"이러한 부작용 기능을 사용하면,  ``mock`` 은 일반 딕셔너리처럼 작동하지만 접근들을 기록합니다. 존재하지 않는 키에 "
+"접근하려고 하면, :exc:`KeyError` 가 발생합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:973
 msgid ""
 "After it has been used you can make assertions about the access using the"
 " normal mock methods and attributes:"
-msgstr ""
+msgstr "사용 된 후에는 일반적인 mock 메서드와 속성을 사용하여 접근권에 대한 어써션을 만들 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:985
 msgid "Mock subclasses and their attributes"
-msgstr ""
+msgstr "Mock 하위 클래스와 그 속성들"
 
 #: ../Doc/library/unittest.mock-examples.rst:987
 msgid ""
 "There are various reasons why you might want to subclass :class:`Mock`. "
 "One reason might be to add helper methods. Here's a silly example:"
 msgstr ""
+":class:`Mock` 을 하위 클래스로 만들려고 하는데는 여러 이유가 있습니다. 한 가지 이유는 도우미 메서드를 추가하는 것일 "
+"수 있습니다. 다음은 바보같은 예입니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1003
 msgid ""
@@ -837,6 +1031,10 @@ msgid ""
 "helper methods then they'll also be available on the attributes and "
 "return value mock of instances of your subclass."
 msgstr ""
+"``Mock`` 인스턴스의 표준 동작은 속성과 반환 값 mock이 접근되는 mock 과 같은 타입이라는 것입니다. 이것은 "
+"``Mock`` 속성이 ``Mocks`` 이고, ``MagicMock`` 속성이 ``MagicMocks`` 임을 보장합니다 "
+"[#]_. 따라서 하위 클래스로 도우미 메서드를 추가하려면, 하위 클래스의 인스턴스에 대한 속성과 반환 값 mock 에 대해서 "
+"사용할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1019
 msgid ""
@@ -846,6 +1044,11 @@ msgid ""
 "<https://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html>`_."
 " Having this applied to attributes too actually causes errors."
 msgstr ""
+"때때로 이것은 불편합니다. 예를 들어, 한 유저가 "
+"<https://code.google.com/archive/p/mock/issues/105>`_ mock 을 하위 클래스로 만들어 "
+"`Twisted 어댑터를 "
+"<https://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html>`_."
+" 만들었습니다. 이것을 속성에 적용하면 실제로 오류가 발생합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1025
 msgid ""
@@ -855,6 +1058,9 @@ msgid ""
 "method. The signature is that it takes arbitrary keyword arguments "
 "(``**kwargs``) which are then passed onto the mock constructor:"
 msgstr ""
+"(모든 속성에서) ``Mock`` 은 ``_get_child_mock`` 호출을 이용하여, 속성과 반환 값에 대한 "
+"\"하위-mock\" 을 만듭니다. 이 메서드를 오버라이드하는 것이므로, 하위 클래스가 속성에 사용되지 않게 할 수 있습니다.서명은"
+" 임의의 키워드 인자(``**kwargs``) 를 가지고, mock 생성자로 전달 된다는 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1042
 msgid ""
@@ -862,10 +1068,12 @@ msgid ""
 "callable variant because otherwise non-callable mocks couldn't have "
 "callable methods."
 msgstr ""
+"이 규칙에 대한 예외는 호출 할 수 없는 mock입니다. 호출 할 수 없는 mock은 호출 가능한 메서드를 가질 수 없기 때문에, "
+"속성은 호출 가능한 형태를 사용합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1048
 msgid "Mocking imports with patch.dict"
-msgstr ""
+msgstr "patch.dict 임포트 Mocking"
 
 #: ../Doc/library/unittest.mock-examples.rst:1050
 msgid ""
@@ -873,6 +1081,8 @@ msgid ""
 "inside a function. These are harder to mock because they aren't using an "
 "object from the module namespace that we can patch out."
 msgstr ""
+"mock이 어려울 수 있는 한 가지 경우는 함수 내에 로컬 임포트가 있는 경우입니다. 우리가 패치 할 수있는 모듈 네임스페이스의 "
+"객체를 사용하지 않기 때문에, mock 하기가 더 어렵습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1054
 msgid ""
@@ -883,6 +1093,9 @@ msgid ""
 "than an unconditional local import (store the module as a class or module"
 " attribute and only do the import on first use)."
 msgstr ""
+"일반적으로 로컬 임포트는 피해야 합니다. 순환적 종속성을 종종 방지하기 위해 수행됩니다. 이 문제는 *일반적으로* 문제를 해결하거나"
+" (코드를 리팩토링하는) 임포트를 지연시켜 \"최대 비용\"을 방지하는 훨씬 좋은 방법이 있습니다. 이는 무조건 로컬 임포트 "
+"(모듈을 클래스 또는 모듈 속성으로 저장하고, 처음 사용할때 만 임포트)를 하는 것 보다 더 나은 방법으로 해결할 수도 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1061
 msgid ""
@@ -893,6 +1106,9 @@ msgid ""
 "put in `sys.modules`, so usually when you import something you get a "
 "module back. This need not be the case however."
 msgstr ""
+"그 외에도 ``mock`` 를 사용하여 임포트 결과에 영향을 주는 방법도 있습니다. 임포팅은 :data:`sys.modules` "
+"딕셔너리로부터 *객체*\\를 패치합니다. 모듈이 될 필요 없는 *객체*\\를 가져오는 것을 주의합시다. 모듈을 처음으로 임포팅하면 "
+"모듈 객체가 `sys.modules` 에 저장되어, 보통 무언가를 임포트 할때 모듈을 되찾습니다. 그러나 그럴 필요는 없습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1068
 msgid ""
@@ -902,28 +1118,34 @@ msgid ""
 "exits, the with statement body is complete or ``patcher.stop()`` is "
 "called) then whatever was there previously will be restored safely."
 msgstr ""
+"즉 :func:`patch.dict` 를 사용하여 *일시적으로* mock 을 :data:`sys.modules` 에 배치합니다. 이"
+" 패치가 임포트 되어있는 동안, mock 을 가져옵니다. 패치가 완료되면 (데코레이팅 된 함수가 종료되면, with 문이 완전히 "
+"완료되거나 ``patcher.stop()`` 이 호출 됩니다.) 이전 무엇이 있든 안전하게 복원 될 것입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1074
 msgid "Here's an example that mocks out the 'fooble' module."
-msgstr ""
+msgstr "다음은 'fooble' 모듈을 목아웃하는 예제입니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1085
 msgid ""
 "As you can see the ``import fooble`` succeeds, but on exit there is no "
 "'fooble' left in :data:`sys.modules`."
 msgstr ""
+"``import fooble`` 이 성공한 것을 볼 수 있지만, 종료될 때에는 :data:`sys.modules` 에 "
+"'fooble' 이 남아 있지 않습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1088
 msgid "This also works for the ``from module import name`` form:"
-msgstr ""
+msgstr "이것은 ``from module import name`` 형식에서도 작동합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1098
 msgid "With slightly more work you can also mock package imports:"
-msgstr ""
+msgstr "약간 더 많은 작업을 통해 패키지 임포트를 mock 할 수 있습니다.:"
 
+# TODO (2019. 5) less verbose
 #: ../Doc/library/unittest.mock-examples.rst:1111
 msgid "Tracking order of calls and less verbose call assertions"
-msgstr ""
+msgstr "호출 순서와 적은 추가 정보 호출 어써션 추적하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:1113
 msgid ""
@@ -933,6 +1155,9 @@ msgid ""
 "objects, however we can use :attr:`~Mock.mock_calls` to achieve the same "
 "effect."
 msgstr ""
+":class:`Mock` 클래스는 :attr:`~Mock.method_calls` 속성을 통해 mock 객체에서 메서드 호출 순서를"
+" 추적 할 수 있다. 별도의 mock 객체 사이의 호출 순서를 추적하는 것은 허용하지 않지만, "
+":attr:`~Mock.mock_calls` 를 사용하면 같은 효과를 얻을 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1118
 msgid ""
@@ -941,12 +1166,15 @@ msgid ""
 " separate mocks from a parent one. Calls to those child mock will then "
 "all be recorded, in order, in the ``mock_calls`` of the parent:"
 msgstr ""
+"왜냐하면 mock은 ``mock_calls`` 에 있는 자식 mock에 대한 호출을 추적하고, mock의 임의 속성에 접근하면 자식"
+" mock 을 생성하기 때문에 부모 mock 과 별도로 mock 을 생성할 수 있습니다. 그 자식 mock 호출은 모든 부모의 "
+"``mock_calls` 에 순서대로 기록됩니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1135
 msgid ""
 "We can then assert about the calls, including the order, by comparing "
 "with the ``mock_calls`` attribute on the manager mock:"
-msgstr ""
+msgstr "관리자 mock 의 ``mock_calls`` 속성과 비교하면서, 순서를 포함한 호출에 대해 어서트를 할 수 있습니다. "
 
 #: ../Doc/library/unittest.mock-examples.rst:1142
 msgid ""
@@ -954,6 +1182,8 @@ msgid ""
 "attach them to a manager mock using the :meth:`~Mock.attach_mock` method."
 " After attaching calls will be recorded in ``mock_calls`` of the manager."
 msgstr ""
+"``patch`` 를 생성되고 있다면, mocks 을 :meth:`~Mock.attach_mock` 메서드를 이용하여 mock "
+"관리자에 첨부 할 수 있습니다.호출이 첨부되면, 관리자의 ``mock_calls`` 에 기록됩니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1162
 msgid ""
@@ -963,12 +1193,17 @@ msgid ""
 "(constructed with the :data:`call` object). If that sequence of calls are"
 " in :attr:`~Mock.mock_calls` then the assert succeeds."
 msgstr ""
+"많은 호출이 생성되었지만, 특정 순서에만 관심있다면 :meth:`~Mock.assert_has_calls` 메서드를 사용하는 방법도"
+" 있습니다. 이것은 (호출 객체로 생성된) 호출 목록을 가지고 있습니다 해당 호출 순서가 "
+":attr:`~Mock.mock_calls` 이면, 어서트가 성공합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1176
 msgid ""
 "Even though the chained call ``m.one().two().three()`` aren't the only "
 "calls that have been made to the mock, the assert still succeeds."
 msgstr ""
+"비록 체이닝 된 호출 ``m.one().two().three()`` 이 mock호출에 유일한 호출은 아니지만, 어서트는 계속 "
+"성공합니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1179
 msgid ""
@@ -977,16 +1212,20 @@ msgid ""
 "care about the order. In this case you can pass ``any_order=True`` to "
 "``assert_has_calls``:"
 msgstr ""
+"때때로 mock은 여러번 호출 될 수 있으며, *일부* 호출에 대해서만 관심이 있습니다. 순서에 대해 신경쓰지 않을 수도 있습니다."
+" 이 경우 ``any_order=True`` 를 ``assert_has_calls`` 에 전달 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1191
 msgid "More complex argument matching"
-msgstr ""
+msgstr "조금 더 복잡한 인자 매칭하기"
 
 #: ../Doc/library/unittest.mock-examples.rst:1193
 msgid ""
 "Using the same basic concept as :data:`ANY` we can implement matchers to "
 "do more complex assertions on objects used as arguments to mocks."
 msgstr ""
+":data:`ANY`\\와 같은 기본 개념을 사용하여, 우리는 mock에 인자로 사용되는 객체에 대해 좀 더 복잡한 어서션을 "
+"수행하는 matcher를 구현 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1196
 msgid ""
@@ -997,28 +1236,31 @@ msgid ""
 "of the attributes of this object then we can create a matcher that will "
 "check these attributes for us."
 msgstr ""
+"어떤 객체가 mock 에 전달 되는 것을 예상한다고 가정해 봅시다. 이 객체는 기본적으로 객체 동일성 (사용자 정의 클래스에 대한 "
+"파이썬 기본값)을 바탕으로 동등을 비교합니다. :meth:`~Mock.assert_called_with` 사용하려면, 같은 객체를 "
+"전달해야 합니다. 이 객체의 일부만 관심이 있는 경우 이러한 속성을 확인하는 matcher를 만들 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1203
 msgid ""
 "You can see in this example how a 'standard' call to "
 "``assert_called_with`` isn't sufficient:"
-msgstr ""
+msgstr "이 예제에서 ``assert_called_with`` 에 대한 '표준' 호출이 충분하지 않다는 것을 볼 수 있습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1218
 msgid ""
 "A comparison function for our ``Foo`` class might look something like "
 "this:"
-msgstr ""
+msgstr "``Foo`` 클래스의 비교 함수는 다음과 같습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1230
 msgid ""
 "And a matcher object that can use comparison functions like this for its "
 "equality operation would look something like this:"
-msgstr ""
+msgstr "그리고 동등 연산을 위해 이와 같은 비교 함수를 사용할 수 있는 matcher 객체는 다음과 같습니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1241
 msgid "Putting all this together:"
-msgstr ""
+msgstr "모든것을 하나로 모으기:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1246
 msgid ""
@@ -1029,12 +1271,15 @@ msgid ""
 "they match then ``assert_called_with`` passes, and if they don't an "
 ":exc:`AssertionError` is raised:"
 msgstr ""
+"``Matcher`` 는 비교 함수와 비교할 ``Foo`` 객체로 인스턴스화 됩니다. ``assert_called_with`` 에서"
+" ``Matcher`` 동등 메서드가 호출되어 mock 을 호출한 객체와우리가 만든 matcher 객체와 비교합니다 만약 일치하면 "
+"``assert_called_with`` 가 통과되고, 그렇지 않으면 :exc:`AssertionError` 가 발생합니다.:"
 
 #: ../Doc/library/unittest.mock-examples.rst:1259
 msgid ""
 "With a bit of tweaking you could have the comparison function raise the "
 ":exc:`AssertionError` directly and provide a more useful failure message."
-msgstr ""
+msgstr "약간 수정하면 비교 함수가 :exc:`AssertionError` 를 직접 발생시키고, 유용한 실패 메시지를 제공 할 수 있습니다."
 
 #: ../Doc/library/unittest.mock-examples.rst:1262
 msgid ""
@@ -1045,37 +1290,7 @@ msgid ""
 "<https://pyhamcrest.readthedocs.io/en/release-1.8/integration/#module-"
 "hamcrest.library.integration.match_equality>`_)."
 msgstr ""
-
-#~ msgid ""
-#~ "Sometimes this is inconvenient. For "
-#~ "example, `one user "
-#~ "<https://code.google.com/p/mock/issues/detail?id=105>`_ is "
-#~ "subclassing mock to created a `Twisted"
-#~ " adaptor "
-#~ "<https://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html>`_."
-#~ " Having this applied to attributes "
-#~ "too actually causes errors."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "As of version 1.5, the Python "
-#~ "testing library `PyHamcrest "
-#~ "<https://pyhamcrest.readthedocs.org/>`_ provides similar"
-#~ " functionality, that may be useful "
-#~ "here, in the form of its equality"
-#~ " matcher (`hamcrest.library.integration.match_equality "
-#~ "<https://pyhamcrest.readthedocs.org/en/release-1.8/integration"
-#~ "/#module-hamcrest.library.integration.match_equality>`_)."
-#~ msgstr ""
-
-#~ msgid ""
-#~ "When you nest patch decorators the "
-#~ "mocks are passed in to the "
-#~ "decorated function in the same order "
-#~ "they applied (the normal *python* order"
-#~ " that decorators are applied). This "
-#~ "means from the bottom up, so in"
-#~ " the example above the mock for "
-#~ "``test_module.ClassName2`` is passed in first."
-#~ msgstr ""
-
+"파이썬 테스트 라이브러리 `PyHamcrest <https://pyhamcrest.readthedocs.io/>`_ 는 버전 1.5"
+" 부터 동등 matcher (`hamcrest.library.integration.match_equality "
+"<https://pyhamcrest.readthedocs.io/en/release-1.8/integration/#module-"
+"hamcrest.library.integration.match_equality>`_) 의 형태로 비슷한 기능을 제공합니다."


### PR DESCRIPTION
안녕하세요. 
[373](https://github.com/python/python-docs-ko/issues/373) library/unittest.mock-examples 번역 PR 요청드립니다.

몇가지 궁금한 점과 의논하고 싶은 것이 있는데요.
1. #: ../Doc/library/unittest.mock-examples.rst:40 build하고 봤을때 번역이 이부분만 안되어 있습니다. 
build 할때 에러도 없어서 제가 어느부분을 놓쳤는지 잘 모르겠네요. 

2. assertion, assert 번역
현재 한국어로 번역하면 '확인'이라는 단어가 가장 어울리는 것 같았습니다.
그러나 '확인'이라는 단어만으로는 위 두 단어의 의미를 온전히 못살리는 것 같아서 
우선은 '어서션, 어서트' 이렇게 번역을 해놓았는데 이부분에 대해서 어떻게 생각하시는지 궁금합니다.

3. 목업(mock up), 몽키패치(monkey patch) 등 그외 용어
현재 한국어로 번역이 어려운 단어의 경우 위에 같이 번역을 했는데 이에 대해서도 어떻게 생각하시는지 의견을 구하고 싶습니다.

이번에도 잘 부탁드립니다 :)