### PR TITLE
메모리 관리 문서에서 "아레나"가 "투기장"으로 번역된 부분 수정

### DIFF
--- a/c-api/memory.po
+++ b/c-api/memory.po
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 #: /Users/flowdas/works/docs/python/src/Doc/c-api/memory.rst:8
 msgid "Memory Management"
@@ -888,7 +888,7 @@ msgstr "pymalloc 아레나 할당자 사용자 정의"
 msgid ""
 "Structure used to describe an arena allocator. The structure has three "
 "fields:"
-msgstr "투기장 할당자를 기술하는 데 사용되는 구조체. 이 구조체에는 세 개의 필드가 있습니다:"
+msgstr "아레나 할당자를 기술하는 데 사용되는 구조체. 이 구조체에는 세 개의 필드가 있습니다:"
 
 #: /Users/flowdas/works/docs/python/src/Doc/c-api/memory.rst:517
 msgid "``void* alloc(void *ctx, size_t size)``"


### PR DESCRIPTION
# Checklists
- [x] build
- [x] spell
- [x] format