### PR TITLE
Fix typo datamodel.po

### DIFF
--- a/reference/datamodel.po
+++ b/reference/datamodel.po
@@ -279,7 +279,7 @@ msgid ""
 "are of course strongly related to mathematical numbers, but subject to "
 "the limitations of numerical representation in computers."
 msgstr ""
-"이것들은 숫자 리터럴에 의해 만들어지고, 산순 연산과 내장 산술 함수들이 결과로 돌려줍니다. 숫자 객체는 불변입니다; 한 번 값이 "
+"이것들은 숫자 리터럴에 의해 만들어지고, 산술 연산과 내장 산술 함수들이 결과로 돌려줍니다. 숫자 객체는 불변입니다; 한 번 값이 "
 "만들어지면 절대 변하지 않습니다. 파이썬의 숫자는 당연히 수학적인 숫자들과 밀접하게 관련되어 있습니다, 하지만 컴퓨터의 숫자 "
 "표현상의 제약을 받고 있습니다."
 


### PR DESCRIPTION
Hello!

There was a minor typo error and I fixed it.
Also I found out there are errors at the past versions(all `3.8` `3.7` `3.6` version).

If there was a reason let me know :)