### PR TITLE
Add Build and lint workflow

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-python@master
         with:
-          python-version: 3
+          python-version: 3.12
       - uses: actions/checkout@master
         with:
           repository: python/cpython

--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -1,0 +1,78 @@
+name: Building and Linting Workflow
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [3.13, 3.9, 3.8, 3.7, 3.6]
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3
+      - run: pip install sphinx-lint
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ matrix.version }}
+      - uses: rffontenelle/sphinx-lint-problem-matcher@v1.0.0
+      - run: sphinx-lint
+
+  build-translation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [3.13, 3.9, 3.8, 3.7, 3.6]
+        format: [html, latex]
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3
+      - uses: actions/checkout@master
+        with:
+          repository: python/cpython
+          ref: ${{ matrix.version }}
+      - run: make venv
+        working-directory: ./Doc
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ matrix.version }}
+          path: Doc/locales/ko/LC_MESSAGES
+      - run: git pull
+        working-directory: ./Doc/locales/ko/LC_MESSAGES
+      - uses: sphinx-doc/github-problem-matcher@v1.1
+      - run: make -e SPHINXOPTS="--color -D language='ko' -W --keep-going" ${{ matrix.format }}
+        working-directory: ./Doc
+      - uses: actions/upload-artifact@master
+        if: success() || failure()
+        with:
+          name: build-${{ matrix.version }}-${{ matrix.format }}
+          path: Doc/build/${{ matrix.format }}
+
+  output-pdf:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [3.13, 3.9, 3.8, 3.7, 3.6]
+    needs: ['build-translation']
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: build-${{ matrix.version }}-latex
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y latexmk texlive-xetex fonts-freefont-otf xindy
+      - run: make
+      - uses: actions/upload-artifact@master
+        with:
+          name: build-${{ matrix.version }}-pdf
+          path: .


### PR DESCRIPTION
Inspired by pl's lint-and-build.yml. Example run: https://github.com/python/python-docs-pl/actions/runs/14550280751 (less the Transifex parts)

Run of this workflow: https://github.com/StanFromIreland/python-docs-ko/actions/runs/14553083085

Note that there are issues in the older Docs (see run above) so it is up to you @flowdas as to what versions you wish to test.